### PR TITLE
商品一覧表示機能１

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,8 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    # @items = Item.order('created_at DESC')
+    @items = Item.order('created_at DESC')
+    # @items = Item.all
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,11 +134,11 @@
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
-          <% if @item.present? && @item.sold_out? %> 
+          <%# if @item.present? && @item.sold_out? %> 
             <div class='sold-out'>
               <span>Sold Out!!</span>
             </div>
-          <% end %> 
+          <%# end %> 
 
         </div>
         <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -135,9 +135,9 @@
           <%= image_tag item.image, class: "item-img" %>
 
           <%# if @item.present? && @item.sold_out? %> 
-            <div class='sold-out'>
+            <%# <div class='sold-out'>
               <span>Sold Out!!</span>
-            </div>
+            </div> %>
           <%# end %> 
 
         </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,20 +128,17 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
     <% @items.order(created_at: :desc).each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
           <% if @item.present? && @item.sold_out? %> 
             <div class='sold-out'>
               <span>Sold Out!!</span>
             </div>
           <% end %> 
-          <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
@@ -159,10 +156,7 @@
         <% end %>
       </li>
     <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
     <% if @items.empty? %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -182,8 +176,6 @@
         <% end %>
       </li>
     <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,24 +129,27 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% @items.order(created_at: :desc).each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+          <% if @item.present? && @item.sold_out? %> 
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+          <% end %> 
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.product_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.delivery_price.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,10 +158,12 @@
         </div>
         <% end %>
       </li>
+    <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
+    <% if @items.empty? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,6 +181,7 @@
         </div>
         <% end %>
       </li>
+    <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>


### PR DESCRIPTION
# what 
商品一覧表示機能を付けました。
 売却済みの商品は、画像上に「sold out」の文字が表示される部分は行なっておりません。

* 商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/ad85ed30fe7922fdbc42d371d8974437
*商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/45e2888bf7937c6fb72532b6ebcea183

# why
使っているユーザが簡単に商品を見る事ができるため。